### PR TITLE
Configure at rule empty line before

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,20 @@
 module.exports = {
     "extends": "stylelint-config-standard",
     "rules": {
+        "at-rule-empty-line-before": [
+            "always", {
+                "except": [
+                    "blockless-after-same-name-blockless",
+                    "first-nested",
+                ],
+                "ignore": [
+                    "after-comment"
+                ],
+                "ignoreAtRules": [
+                    "import"
+                ]
+            }
+        ],
         "at-rule-no-unknown": [
             true,
             {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connectholland-stylelint-config",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Connect Holland stylelint config",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Default config for `at-rule-empty-line-before ` is copied from [stylelint-config-standard](https://github.com/stylelint/stylelint-config-standard/blob/master/index.js#L6-L12).
Added the `ignoreAtRules` for import.